### PR TITLE
Fix IllegalStateException: FragmentManager is already executing trans…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,8 +16,8 @@ POM_ARTIFACT_ID=permission-bitte
 POM_ARTIFACT_URL=permission-bitte
 POM_PACKAGING=aar
 
-VERSION_NAME=1.0.0
-VERSION_CODE=4
+VERSION_NAME=1.0.1
+VERSION_CODE=5
 GROUP=com.sensorberg.libs
 
 POM_DESCRIPTION=Easiest way to ask for user permission in Android

--- a/permission-bitte/src/main/java/com/sensorberg/permissionbitte/PermissionBitte.java
+++ b/permission-bitte/src/main/java/com/sensorberg/permissionbitte/PermissionBitte.java
@@ -57,7 +57,7 @@ public class PermissionBitte {
       activity.getSupportFragmentManager()
               .beginTransaction()
               .add(permissionBitteFragment, TAG)
-              .commitNowAllowingStateLoss();
+              .commitAllowingStateLoss();
     }
 
     return permissionBitteFragment;


### PR DESCRIPTION
…actions

This happens when a fragment instantiates PermissionBitte from inside onCreateView. Example:
```
fun onCreateView(...) {
   val root = .. inflate
   PermissionBitte.permissions(activity).observe(viewLifecycleOwner, permissionStatus)
}
```

using the normal commit (without now) will simply enqueue the transaction and it will get executed properly later